### PR TITLE
Creates architecture tests

### DIFF
--- a/Northwind.sln
+++ b/Northwind.sln
@@ -39,6 +39,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebUI.IntegrationTests", "T
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Persistence.IntegrationTests", "Tests\Persistence.IntegrationTests\Persistence.IntegrationTests.csproj", "{FCFF633E-3675-41FE-8A2C-18009C744C00}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Solution.ArchitectureTests", "Tests\Solution.ArchitectureTests\Solution.ArchitectureTests.csproj", "{0AFB0CBB-70CB-4033-A371-D59B1C258F90}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -85,6 +87,10 @@ Global
 		{FCFF633E-3675-41FE-8A2C-18009C744C00}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FCFF633E-3675-41FE-8A2C-18009C744C00}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FCFF633E-3675-41FE-8A2C-18009C744C00}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0AFB0CBB-70CB-4033-A371-D59B1C258F90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AFB0CBB-70CB-4033-A371-D59B1C258F90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0AFB0CBB-70CB-4033-A371-D59B1C258F90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0AFB0CBB-70CB-4033-A371-D59B1C258F90}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -103,6 +109,7 @@ Global
 		{FD68C950-322B-467C-82A6-99C084BAB50B} = {9FEDAEFB-297C-4201-8FAA-F502F94CAFED}
 		{22B85BF9-27F9-4C0C-AB6D-C05014C022E5} = {9FEDAEFB-297C-4201-8FAA-F502F94CAFED}
 		{FCFF633E-3675-41FE-8A2C-18009C744C00} = {9FEDAEFB-297C-4201-8FAA-F502F94CAFED}
+		{0AFB0CBB-70CB-4033-A371-D59B1C258F90} = {9FEDAEFB-297C-4201-8FAA-F502F94CAFED}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0D5D0CA3-C6B8-436C-82B0-39820C8A13FA}

--- a/Tests/Solution.ArchitectureTests/Solution.ArchitectureTests.csproj
+++ b/Tests/Solution.ArchitectureTests/Solution.ArchitectureTests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+        <PackageReference Include="NetArchTest.Rules" Version="1.2.3" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+        <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\Src\Application\Application.csproj" />
+      <ProjectReference Include="..\..\Src\Common\Common.csproj" />
+      <ProjectReference Include="..\..\Src\Domain\Domain.csproj" />
+      <ProjectReference Include="..\..\Src\Infrastructure\Infrastructure.csproj" />
+      <ProjectReference Include="..\..\Src\Persistence\Persistence.csproj" />
+      <ProjectReference Include="..\..\Src\WebUI\WebUI.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Tests/Solution.ArchitectureTests/WebUIArchitectureTests.cs
+++ b/Tests/Solution.ArchitectureTests/WebUIArchitectureTests.cs
@@ -1,0 +1,85 @@
+using System.Reflection;
+using System.Text;
+using NetArchTest.Rules;
+using Northwind.WebUI;
+using Xunit;
+
+namespace Solution.ArchitectureTests
+{
+    public class WebUIArchitectureTests
+    {
+        private static Assembly WebUiAssembly => typeof(Startup).Assembly;
+        
+        [Fact]
+        public void Controllers_MustHaveNameEndingInController()
+        {
+            var result = Types.InAssembly(WebUiAssembly)
+                .That()
+                .ResideInNamespace("Northwind.WebUI.Controllers")
+                .And().AreClasses()
+                .And().AreNotAbstract()
+                .Should().HaveNameEndingWith("Controller")
+                .GetResult();
+            
+            Assert.True(result.IsSuccessful, GetErrorMessage(result));
+        }
+        
+        [Fact]
+        public void Controllers_MustNotDependOnInfrastructure()
+        {
+            var result = Types.InAssembly(WebUiAssembly)
+                .That()
+                .ResideInNamespace("Northwind.WebUI.Controllers")
+                .ShouldNot()
+                .HaveDependencyOn("Northwind.Infrastructure")
+                .GetResult();
+            
+            Assert.True(result.IsSuccessful, GetErrorMessage(result));
+        }
+        
+        [Fact]
+        public void Controllers_MustNotDependOnPersistence()
+        {
+            var result = Types.InAssembly(WebUiAssembly)
+                .That()
+                .ResideInNamespace("Northwind.WebUI.Controllers")
+                .ShouldNot()
+                .HaveDependencyOn("Northwind.Persistence")
+                .GetResult();
+            
+            Assert.True(result.IsSuccessful, GetErrorMessage(result));
+        }
+        
+        [Fact]
+        public void Controllers_MustNotDependOnDomain()
+        {
+            var result = Types.InAssembly(WebUiAssembly)
+                .That()
+                .ResideInNamespace("Northwind.WebUI.Controllers")
+                .ShouldNot()
+                .HaveDependencyOn("Northwind.Domain")
+                .GetResult();
+            
+            Assert.True(result.IsSuccessful, GetErrorMessage(result));
+        }
+
+        private static string GetErrorMessage(TestResult result)
+        {
+            if (result.IsSuccessful)
+            {
+                return string.Empty;
+            }
+            
+            var builder = new StringBuilder();
+            builder.AppendLine("Failing types:");
+
+            foreach (var typeName in result.FailingTypeNames)
+            {
+                builder.AppendLine($"  - {typeName}");
+            }
+
+            return builder.ToString();
+
+        }
+    }
+}


### PR DESCRIPTION
Example implementation as to how one can use [NetArchTest](https://www.ben-morris.com/writing-archunit-style-tests-for-net-and-c-for-self-testing-architectures/) to build an anti-corruption layer to protect against improper coupling.

@JasonGT - I've recently watched your NDC 2019 talk and noticed that you cautioned the audience that the `WebUI` layer has a reference to `Infrastructure` for the purpose of DI and if it's used outside of the Startup.cs "hopefully you'll pick that up during a code review".  The unit tests added here provide a mechanism to remove that ambiguity and use tests to validate this type of improper coupling doesn't occur.

The example included here is relatively simplistic, however it could easily be enhanced further.  I thought it would be wise to implement and discuss it here before attempting to incorporate it anywhere else (such as your `Clean.Architecture.Solution.Template` project).  