### PR TITLE
Improve swagger spec.

### DIFF
--- a/Src/Application/Application.csproj
+++ b/Src/Application/Application.csproj
@@ -3,6 +3,11 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Northwind.Application</RootNamespace>
     <AssemblyName>Northwind.Application</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Application/Categories/Commands/UpsertCategory/UpsertCategoryCommand.cs
+++ b/Src/Application/Categories/Commands/UpsertCategory/UpsertCategoryCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Northwind.Application.Common.Interfaces;
@@ -6,14 +7,31 @@ using Northwind.Domain.Entities;
 
 namespace Northwind.Application.Categories.Commands.UpsertCategory
 {
+    /// <summary>
+    /// Update category model.
+    /// </summary>
     public class UpsertCategoryCommand : IRequest<int>
     {
+        /// <summary>
+        /// Id or null.
+        /// </summary>
         public int? Id { get; set; }
 
+        /// <summary>
+        /// Name.
+        /// </summary>
+        [Required]
+        [MaxLength(15)]
         public string Name { get; set; }
 
+        /// <summary>
+        /// Description.
+        /// </summary>
         public string Description { get; set; }
 
+        /// <summary>
+        /// Base64 encoded data of a picture.
+        /// </summary>
         public byte[] Picture { get; set; }
 
         public class UpsertCategoryCommandHandler : IRequestHandler<UpsertCategoryCommand, int>

--- a/Src/Application/Categories/Queries/GetCategoriesList/CategoriesListVm.cs
+++ b/Src/Application/Categories/Queries/GetCategoriesList/CategoriesListVm.cs
@@ -2,10 +2,19 @@
 
 namespace Northwind.Application.Categories.Queries.GetCategoriesList
 {
+    /// <summary>
+    /// Category view model.
+    /// </summary>
     public class CategoriesListVm
     {
+        /// <summary>
+        /// Categories list.
+        /// </summary>
         public IList<CategoryDto> Categories { get; set; }
 
+        /// <summary>
+        /// Total categories count.
+        /// </summary>
         public int Count { get; set; }
     }
 }

--- a/Src/Application/Categories/Queries/GetCategoriesList/CategoryDto.cs
+++ b/Src/Application/Categories/Queries/GetCategoriesList/CategoryDto.cs
@@ -1,17 +1,38 @@
 ﻿using AutoMapper;
 using Northwind.Application.Common.Mappings;
 using Northwind.Domain.Entities;
+using System.ComponentModel.DataAnnotations;
 
 namespace Northwind.Application.Categories.Queries.GetCategoriesList
 {
+    /// <summary>
+    /// Category.
+    /// </summary>
+    /// <example>{ "id": 1, "name": "Sea food" } </example>
     public class CategoryDto : IMapFrom<Category>
     {
+        /// <summary>
+        /// Id.
+        /// </summary>
+        [Required]
         public int Id { get; set; }
 
+        /// <summary>
+        /// Name.
+        /// </summary>
+        /// <example>"Sea food"</example>
+        [Required]
+        [MaxLength(15)]
         public string Name { get; set; }
 
+        /// <summary>
+        /// Description.
+        /// </summary>
         public string Description { get; set; }
 
+        /// <summary>
+        /// Picture.
+        /// </summary>
         public byte[] Picture { get; set; }
 
         public void Mapping(Profile profile)

--- a/Src/WebUI/ClientApp/src/app/northwind-traders-api.ts
+++ b/Src/WebUI/ClientApp/src/app/northwind-traders-api.ts
@@ -15,8 +15,21 @@ import { HttpClient, HttpHeaders, HttpResponse, HttpResponseBase } from '@angula
 export const API_BASE_URL = new InjectionToken<string>('API_BASE_URL');
 
 export interface ICategoriesClient {
+    /**
+     * Get all gategories.
+     * @return Returns list of all categories.
+     */
     getAll(): Observable<CategoriesListVm>;
-    upsert(command: UpsertCategoryCommand): Observable<void>;
+    /**
+     * Updates existing category or inserts a new category.
+     * @param command Upsert category command.
+     * @return Id of created/updated category.
+     */
+    upsert(command: UpsertCategoryCommand): Observable<number>;
+    /**
+     * Delete category by id.
+     * @param id Id of deleting category.
+     */
     delete(id: number): Observable<void>;
 }
 
@@ -31,6 +44,10 @@ export class CategoriesClient implements ICategoriesClient {
         this.baseUrl = baseUrl ? baseUrl : "";
     }
 
+    /**
+     * Get all gategories.
+     * @return Returns list of all categories.
+     */
     getAll(): Observable<CategoriesListVm> {
         let url_ = this.baseUrl + "/api/Categories/GetAll";
         url_ = url_.replace(/[?&]$/, "");
@@ -79,7 +96,12 @@ export class CategoriesClient implements ICategoriesClient {
         return _observableOf<CategoriesListVm>(<any>null);
     }
 
-    upsert(command: UpsertCategoryCommand): Observable<void> {
+    /**
+     * Updates existing category or inserts a new category.
+     * @param command Upsert category command.
+     * @return Id of created/updated category.
+     */
+    upsert(command: UpsertCategoryCommand): Observable<number> {
         let url_ = this.baseUrl + "/api/Categories/Upsert";
         url_ = url_.replace(/[?&]$/, "");
 
@@ -91,6 +113,7 @@ export class CategoriesClient implements ICategoriesClient {
             responseType: "blob",
             headers: new HttpHeaders({
                 "Content-Type": "application/json", 
+                "Accept": "application/json"
             })
         };
 
@@ -101,14 +124,14 @@ export class CategoriesClient implements ICategoriesClient {
                 try {
                     return this.processUpsert(<any>response_);
                 } catch (e) {
-                    return <Observable<void>><any>_observableThrow(e);
+                    return <Observable<number>><any>_observableThrow(e);
                 }
             } else
-                return <Observable<void>><any>_observableThrow(response_);
+                return <Observable<number>><any>_observableThrow(response_);
         }));
     }
 
-    protected processUpsert(response: HttpResponseBase): Observable<void> {
+    protected processUpsert(response: HttpResponseBase): Observable<number> {
         const status = response.status;
         const responseBlob = 
             response instanceof HttpResponse ? response.body : 
@@ -117,7 +140,10 @@ export class CategoriesClient implements ICategoriesClient {
         let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }};
         if (status === 200) {
             return blobToText(responseBlob).pipe(_observableMergeMap(_responseText => {
-            return _observableOf<void>(<any>null);
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = resultData200 !== undefined ? resultData200 : <any>null;
+            return _observableOf(result200);
             }));
         } else {
             return blobToText(responseBlob).pipe(_observableMergeMap(_responseText => {
@@ -129,6 +155,10 @@ export class CategoriesClient implements ICategoriesClient {
         }
     }
 
+    /**
+     * Delete category by id.
+     * @param id Id of deleting category.
+     */
     delete(id: number): Observable<void> {
         let url_ = this.baseUrl + "/api/Categories/Delete/{id}";
         if (id === undefined || id === null)
@@ -1015,8 +1045,11 @@ export class ProductsClient implements IProductsClient {
     }
 }
 
+/** Category view model. */
 export class CategoriesListVm implements ICategoriesListVm {
+    /** Categories list. */
     categories?: CategoryDto[] | undefined;
+    /** Total categories count. */
     count?: number;
 
     constructor(data?: ICategoriesListVm) {
@@ -1058,15 +1091,23 @@ export class CategoriesListVm implements ICategoriesListVm {
     }
 }
 
+/** Category view model. */
 export interface ICategoriesListVm {
+    /** Categories list. */
     categories?: CategoryDto[] | undefined;
+    /** Total categories count. */
     count?: number;
 }
 
+/** Category. */
 export class CategoryDto implements ICategoryDto {
-    id?: number;
-    name?: string | undefined;
+    /** Id. */
+    id!: number;
+    /** Name. */
+    name!: string;
+    /** Description. */
     description?: string | undefined;
+    /** Picture. */
     picture?: string | undefined;
 
     constructor(data?: ICategoryDto) {
@@ -1104,10 +1145,15 @@ export class CategoryDto implements ICategoryDto {
     }
 }
 
+/** Category. */
 export interface ICategoryDto {
-    id?: number;
-    name?: string | undefined;
+    /** Id. */
+    id: number;
+    /** Name. */
+    name: string;
+    /** Description. */
     description?: string | undefined;
+    /** Picture. */
     picture?: string | undefined;
 }
 
@@ -1179,10 +1225,15 @@ export interface IProblemDetails {
     extensions?: { [key: string]: any; } | undefined;
 }
 
+/** Update category model. */
 export class UpsertCategoryCommand implements IUpsertCategoryCommand {
+    /** Id or null. */
     id?: number | undefined;
-    name?: string | undefined;
+    /** Name. */
+    name!: string;
+    /** Description. */
     description?: string | undefined;
+    /** Base64 encoded data of a picture. */
     picture?: string | undefined;
 
     constructor(data?: IUpsertCategoryCommand) {
@@ -1220,10 +1271,15 @@ export class UpsertCategoryCommand implements IUpsertCategoryCommand {
     }
 }
 
+/** Update category model. */
 export interface IUpsertCategoryCommand {
+    /** Id or null. */
     id?: number | undefined;
-    name?: string | undefined;
+    /** Name. */
+    name: string;
+    /** Description. */
     description?: string | undefined;
+    /** Base64 encoded data of a picture. */
     picture?: string | undefined;
 }
 

--- a/Src/WebUI/Controllers/CategoriesController.cs
+++ b/Src/WebUI/Controllers/CategoriesController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Northwind.Application.Categories.Commands.DeleteCategory;
 using Northwind.Application.Categories.Commands.UpsertCategory;
 using Northwind.Application.Categories.Queries.GetCategoriesList;
+using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 
 namespace Northwind.WebUI.Controllers
@@ -31,7 +32,7 @@ namespace Northwind.WebUI.Controllers
         [HttpPost]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesDefaultResponseType]
-        public async Task<ActionResult<int>> Upsert(UpsertCategoryCommand command)
+        public async Task<ActionResult<int>> Upsert([Required]UpsertCategoryCommand command)
         {
             var id = await Mediator.Send(command);
 

--- a/Src/WebUI/Controllers/CategoriesController.cs
+++ b/Src/WebUI/Controllers/CategoriesController.cs
@@ -11,6 +11,10 @@ namespace Northwind.WebUI.Controllers
     [Authorize]
     public class CategoriesController : BaseController
     {
+        /// <summary>
+        /// Get all gategories.
+        /// </summary>
+        /// <returns>Returns list of all categories.</returns>
         [HttpGet]
         [AllowAnonymous]
         public async Task<ActionResult<CategoriesListVm>> GetAll()
@@ -18,16 +22,26 @@ namespace Northwind.WebUI.Controllers
             return Ok(await Mediator.Send(new GetCategoriesListQuery()));
         }
 
+        /// <summary>
+        /// Updates existing category or inserts a new category.
+        /// </summary>
+        /// <remarks>Use id of exsting category to update it. Or NULL to create a new category.</remarks>
+        /// <param name="command">Upsert category command.</param>
+        /// <returns>Id of created/updated category.</returns>
         [HttpPost]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesDefaultResponseType]
-        public async Task<IActionResult> Upsert(UpsertCategoryCommand command)
+        public async Task<ActionResult<int>> Upsert(UpsertCategoryCommand command)
         {
             var id = await Mediator.Send(command);
 
             return Ok(id);
         }
 
+        /// <summary>
+        /// Delete category by id.
+        /// </summary>
+        /// <param name="id">Id of deleting category.</param>
         [HttpDelete("{id}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/Src/WebUI/WebUI.csproj
+++ b/Src/WebUI/WebUI.csproj
@@ -13,6 +13,11 @@
     <!-- Set this to true if you enable server-side prerendering -->
     <BuildServerSideRenderer>false</BuildServerSideRenderer>
     <UserSecretsId>f887bb79-4c4b-46b5-a783-c7ca8d16c955</UserSecretsId>
+	<GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/WebUI/wwwroot/api/specification.json
+++ b/Src/WebUI/wwwroot/api/specification.json
@@ -11,10 +11,11 @@
         "tags": [
           "Categories"
         ],
+        "summary": "Get all gategories.",
         "operationId": "Categories_GetAll",
         "responses": {
           "200": {
-            "description": "",
+            "description": "Returns list of all categories.",
             "content": {
               "application/json": {
                 "schema": {
@@ -31,9 +32,12 @@
         "tags": [
           "Categories"
         ],
+        "summary": "Updates existing category or inserts a new category.",
+        "description": "Use id of exsting category to update it. Or NULL to create a new category.",
         "operationId": "Categories_Upsert",
         "requestBody": {
           "x-name": "command",
+          "description": "Upsert category command.",
           "content": {
             "application/json": {
               "schema": {
@@ -46,7 +50,15 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "Id of created/updated category.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
           },
           "default": {
             "description": "",
@@ -66,12 +78,14 @@
         "tags": [
           "Categories"
         ],
+        "summary": "Delete category by id.",
         "operationId": "Categories_Delete",
         "parameters": [
           {
             "name": "id",
             "in": "path",
             "required": true,
+            "description": "Id of deleting category.",
             "schema": {
               "type": "integer",
               "format": "int32"
@@ -580,10 +594,12 @@
     "schemas": {
       "CategoriesListVm": {
         "type": "object",
+        "description": "Category view model.",
         "additionalProperties": false,
         "properties": {
           "categories": {
             "type": "array",
+            "description": "Categories list.",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/CategoryDto"
@@ -591,28 +607,44 @@
           },
           "count": {
             "type": "integer",
+            "description": "Total categories count.",
             "format": "int32"
           }
         }
       },
       "CategoryDto": {
         "type": "object",
+        "description": "Category.",
+        "example": {
+          "id": 1,
+          "name": "Sea food"
+        },
         "additionalProperties": false,
+        "required": [
+          "id",
+          "name"
+        ],
         "properties": {
           "id": {
             "type": "integer",
+            "description": "Id.",
             "format": "int32"
           },
           "name": {
             "type": "string",
-            "nullable": true
+            "description": "Name.",
+            "maxLength": 15,
+            "minLength": 1,
+            "example": "Sea food"
           },
           "description": {
             "type": "string",
+            "description": "Description.",
             "nullable": true
           },
           "picture": {
             "type": "string",
+            "description": "Picture.",
             "format": "byte",
             "nullable": true
           }
@@ -652,23 +684,32 @@
       },
       "UpsertCategoryCommand": {
         "type": "object",
+        "description": "Update category model.",
         "additionalProperties": false,
+        "required": [
+          "name"
+        ],
         "properties": {
           "id": {
             "type": "integer",
+            "description": "Id or null.",
             "format": "int32",
             "nullable": true
           },
           "name": {
             "type": "string",
-            "nullable": true
+            "description": "Name.",
+            "maxLength": 15,
+            "minLength": 1
           },
           "description": {
             "type": "string",
+            "description": "Description.",
             "nullable": true
           },
           "picture": {
             "type": "string",
+            "description": "Base64 encoded data of a picture.",
             "format": "byte",
             "nullable": true
           }


### PR DESCRIPTION
I've added support for XML comments in a swagger spec. It is just a sample for the CategoriesController. But the same approach can be used for all other controllers and entities.
It is very useful to show additional information like comments and examples in a swagger spec.

![image](https://user-images.githubusercontent.com/1662779/81473032-2c6d6200-9226-11ea-838a-938fb13f0d4e.png)

![image](https://user-images.githubusercontent.com/1662779/81473088-866e2780-9226-11ea-9ec1-48ace0c50c8d.png)

But if you use attributes - you can add information about optional/required fields to the spec. Or maxlen for the strings.
So I believe better to use attributes for this kind of validation, instead of FluentValidation.

@jasontaylordev what do you think about this approach?

Thanks,

