### PR TITLE
Changed classes visibility to internal

### DIFF
--- a/Src/Application/Categories/Commands/DeleteCategory/DeleteCategoryCommand.cs
+++ b/Src/Application/Categories/Commands/DeleteCategory/DeleteCategoryCommand.cs
@@ -11,7 +11,7 @@ namespace Northwind.Application.Categories.Commands.DeleteCategory
     {
         public int Id { get; set; }
 
-        public class DeleteCategoryCommandHandler : IRequestHandler<DeleteCategoryCommand>
+        internal class DeleteCategoryCommandHandler : IRequestHandler<DeleteCategoryCommand>
         {
             private readonly INorthwindDbContext _context;
 

--- a/Src/Application/Categories/Commands/UpsertCategory/UpsertCategoryCommand.cs
+++ b/Src/Application/Categories/Commands/UpsertCategory/UpsertCategoryCommand.cs
@@ -16,7 +16,7 @@ namespace Northwind.Application.Categories.Commands.UpsertCategory
 
         public byte[] Picture { get; set; }
 
-        public class UpsertCategoryCommandHandler : IRequestHandler<UpsertCategoryCommand, int>
+        internal class UpsertCategoryCommandHandler : IRequestHandler<UpsertCategoryCommand, int>
         {
             private readonly INorthwindDbContext _context;
 

--- a/Src/Application/Categories/Queries/GetCategoriesList/GetCategoriesListQueryHandler.cs
+++ b/Src/Application/Categories/Queries/GetCategoriesList/GetCategoriesListQueryHandler.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Northwind.Application.Categories.Queries.GetCategoriesList
 {
-    public class GetCategoriesListQueryHandler : IRequestHandler<GetCategoriesListQuery, CategoriesListVm>
+    internal class GetCategoriesListQueryHandler : IRequestHandler<GetCategoriesListQuery, CategoriesListVm>
     {
         private readonly INorthwindDbContext _context;
         private readonly IMapper _mapper;

--- a/Src/Application/Common/Behaviours/RequestLogger.cs
+++ b/Src/Application/Common/Behaviours/RequestLogger.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Northwind.Application.Common.Behaviours
 {
-    public class RequestLogger<TRequest> : IRequestPreProcessor<TRequest>
+    internal class RequestLogger<TRequest> : IRequestPreProcessor<TRequest>
     {
         private readonly ILogger _logger;
         private readonly ICurrentUserService _currentUserService;

--- a/Src/Application/Common/Behaviours/RequestPerformanceBehaviour.cs
+++ b/Src/Application/Common/Behaviours/RequestPerformanceBehaviour.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Northwind.Application.Common.Behaviours
 {
-    public class RequestPerformanceBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    internal class RequestPerformanceBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
     {
         private readonly Stopwatch _timer;
         private readonly ILogger<TRequest> _logger;

--- a/Src/Application/Common/Behaviours/RequestValidationBehavior.cs
+++ b/Src/Application/Common/Behaviours/RequestValidationBehavior.cs
@@ -8,7 +8,7 @@ using ValidationException = Northwind.Application.Common.Exceptions.ValidationEx
 
 namespace Northwind.Application.Common.Behaviours
 {
-    public class RequestValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    internal class RequestValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
         where TRequest : IRequest<TResponse>
     {
         private readonly IEnumerable<IValidator<TRequest>> _validators;

--- a/Src/Domain/Entities/Category.cs
+++ b/Src/Domain/Entities/Category.cs
@@ -9,7 +9,7 @@ namespace Northwind.Domain.Entities
             Products = new HashSet<Product>();
         }
 
-        public int CategoryId { get; set; }
+        public int CategoryId { get; private set; }
         public string CategoryName { get; set; }
         public string Description { get; set; }
         public byte[] Picture { get; set; }

--- a/Src/Infrastructure/Files/CsvFileBuilder.cs
+++ b/Src/Infrastructure/Files/CsvFileBuilder.cs
@@ -6,7 +6,7 @@ using Northwind.Application.Products.Queries.GetProductsFile;
 
 namespace Northwind.Infrastructure.Files
 {
-    public class CsvFileBuilder : ICsvFileBuilder
+    internal class CsvFileBuilder : ICsvFileBuilder
     {
         public byte[] BuildProductsFile(IEnumerable<ProductRecordDto> records)
         {

--- a/Src/Infrastructure/Files/ProductFileRecordMap.cs
+++ b/Src/Infrastructure/Files/ProductFileRecordMap.cs
@@ -3,7 +3,7 @@ using Northwind.Application.Products.Queries.GetProductsFile;
 
 namespace Northwind.Infrastructure.Files
 {
-    public sealed class ProductFileRecordMap : ClassMap<ProductRecordDto>
+    internal sealed class ProductFileRecordMap : ClassMap<ProductRecordDto>
     {
         public ProductFileRecordMap()
         {

--- a/Src/Infrastructure/Identity/UserManagerService.cs
+++ b/Src/Infrastructure/Identity/UserManagerService.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Northwind.Infrastructure.Identity
 {
-    public class UserManagerService : IUserManager
+    internal class UserManagerService : IUserManager
     {
         private readonly UserManager<ApplicationUser> _userManager;
 

--- a/Src/Infrastructure/MachineDateTime.cs
+++ b/Src/Infrastructure/MachineDateTime.cs
@@ -3,7 +3,7 @@ using Northwind.Common;
 
 namespace Northwind.Infrastructure
 {
-    public class MachineDateTime : IDateTime
+    internal class MachineDateTime : IDateTime
     {
         public DateTime Now => DateTime.Now;
 

--- a/Src/Infrastructure/NotificationService.cs
+++ b/Src/Infrastructure/NotificationService.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Northwind.Infrastructure
 {
-    public class NotificationService : INotificationService
+    internal class NotificationService : INotificationService
     {
         public Task SendAsync(MessageDto message)
         {

--- a/Src/Persistence/Configurations/CategoryConfiguration.cs
+++ b/Src/Persistence/Configurations/CategoryConfiguration.cs
@@ -4,7 +4,7 @@ using Northwind.Domain.Entities;
 
 namespace Northwind.Persistence.Configurations
 {
-    public class CategoryConfiguration : IEntityTypeConfiguration<Category>
+    internal class CategoryConfiguration : IEntityTypeConfiguration<Category>
     {
         public void Configure(EntityTypeBuilder<Category> builder)
         {


### PR DESCRIPTION
There are too many public classes.
All domain classes and interfaces must be public. But better to mark implementations of these interfaces as internal for better encapsulation.
Samples:
 - When Id is generated by the DB a setter for the Id can be private.
 - The same for collections (this is already implemented).
It is a class contract - all public methods and setters (setter is also method).

But we can use the same approach for modules (projects in a solution). Module contract - it is all public classes in this module: Entities, Enums, Events, Interfaces, Exceptions, and so on.
Domain - all classes are public.
Application - project interface consists of Command, Queries, and DTOs. All handlers can be marked as internal.
Infrastructure - most of the classes are interface implementation. So these classes can be marked as internal. Ideally - in this module exists only one public class - for DependencyInjection.

About unit test - you can share internals to the test project via InternalsVisibleTo Attribute 
https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.internalsvisibletoattribute?view=netcore-3.1